### PR TITLE
fix: Raise error on null payload

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,4 +35,4 @@ require (
 
 replace github.com/openweb3/web3go => github.com/scroll-tech/web3go v0.0.0-20230607200109-31182049a33b
 
-replace github.com/openweb3/go-rpc-provider => github.com/scroll-tech/go-rpc-provider v0.0.0-20230619084629-1c1088e218fc
+replace github.com/openweb3/go-rpc-provider => github.com/scroll-tech/go-rpc-provider v0.0.0-20230619123848-99cc70301fd1

--- a/go.sum
+++ b/go.sum
@@ -620,8 +620,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43MRiaGWX1Nig=
-github.com/scroll-tech/go-rpc-provider v0.0.0-20230619084629-1c1088e218fc h1:M0q3AHLrDeSbfpjT1g6N5u8ySbMw0rVH6+pcwXyUJAc=
-github.com/scroll-tech/go-rpc-provider v0.0.0-20230619084629-1c1088e218fc/go.mod h1:DYz40TbzhzyTA06UFqGIKSXp0uFot6ZKh4QarD//eZ0=
+github.com/scroll-tech/go-rpc-provider v0.0.0-20230619123848-99cc70301fd1 h1:IA55XfA6UfqtFIzZhmr9aAg8i87yqQBK//IN7cHPXQQ=
+github.com/scroll-tech/go-rpc-provider v0.0.0-20230619123848-99cc70301fd1/go.mod h1:DYz40TbzhzyTA06UFqGIKSXp0uFot6ZKh4QarD//eZ0=
 github.com/scroll-tech/web3go v0.0.0-20230607200109-31182049a33b h1:7bkp4+6SFswmPYda+V/FZSivOD9eSrOcx4FFj0djyYo=
 github.com/scroll-tech/web3go v0.0.0-20230607200109-31182049a33b/go.mod h1:nzov9bieJKvQFqJ1gIfvNn3LFO63pdp1C8dP4qv0TmA=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=


### PR DESCRIPTION
Handle queries like `curl -H 'Content-Type: application/json' -d 'null' localhost:8545` correctly. Related change: https://github.com/openweb3/go-rpc-provider/pull/15